### PR TITLE
Remove hard coded dependency on feature size

### DIFF
--- a/data_loaders.py
+++ b/data_loaders.py
@@ -45,7 +45,7 @@ class DataLoader():
             os.path.join(data_dir, "ani_gdb_s05.h5"),
             os.path.join(data_dir, "ani_gdb_s06.h5"),
             os.path.join(data_dir, "ani_gdb_s07.h5"),
-            os.path.join(data_dir, "ani_gdb_s08.h5"),
+            # os.path.join(data_dir, "ani_gdb_s08.h5"),
         ]
 
         if calibration_file:

--- a/data_loaders.py
+++ b/data_loaders.py
@@ -45,7 +45,7 @@ class DataLoader():
             os.path.join(data_dir, "ani_gdb_s05.h5"),
             os.path.join(data_dir, "ani_gdb_s06.h5"),
             os.path.join(data_dir, "ani_gdb_s07.h5"),
-            # os.path.join(data_dir, "ani_gdb_s08.h5"),
+            os.path.join(data_dir, "ani_gdb_s08.h5"),
         ]
 
         if calibration_file:

--- a/gdb8.py
+++ b/gdb8.py
@@ -52,7 +52,10 @@ def main():
         # max_local_epoch_count number of epochs have been run and no progress has been made, we decrease the learning
         # rate and restore the best found parameters.
 
-        trainer = TrainerMultiGPU(sess, n_gpus=int(args.gpus))
+        trainer = TrainerMultiGPU(
+            sess,
+            n_gpus=int(args.gpus),
+            layer_sizes=(128, 128, 64, 1))
 
         if os.path.exists(save_dir):
             print("Restoring existing model from", save_dir)

--- a/gpu_featurizer/ani_op.cc.cu
+++ b/gpu_featurizer/ani_op.cc.cu
@@ -21,28 +21,6 @@ using namespace tensorflow;
 using CPUDevice = Eigen::ThreadPoolDevice;
 using GPUDevice = Eigen::GpuDevice;
 
-namespace black_magic
-{
-    template<unsigned... digits>
-    struct to_chars { static const char value[]; };
-
-    template<unsigned... digits>
-    const char to_chars<digits...>::value[] = {('0' + digits)..., 0};
-
-    template<unsigned rem, unsigned... digits>
-    struct explode : explode<rem / 10, rem % 10, digits...> {};
-
-    template<unsigned... digits>
-    struct explode<0, digits...> : to_chars<digits...> {};
-}
-
-template<unsigned num>
-struct num_to_string : black_magic::explode<num / 10, num % 10> {};
-
-
-std::string a1("feature_size: int = ");
-std::string a2(num_to_string<TOTAL_FEATURE_SIZE>::value);
-
 REGISTER_OP("Ani")
   .Input("xs: float32")
   .Input("ys: float32")
@@ -56,7 +34,7 @@ REGISTER_OP("Ani")
   .Output("c_feat: float32")
   .Output("n_feat: float32")
   .Output("o_feat: float32")
-  .Attr(a1+a2)
+  .Attr("feature_size: int = "+std::to_string(TOTAL_FEATURE_SIZE))
   .SetShapeFn([](::tensorflow::shape_inference::InferenceContext* c) {
     // the output shapes are determined by the number of elements in acs
     // c->set_output(0, c->input(0));

--- a/gpu_featurizer/kernel.cu
+++ b/gpu_featurizer/kernel.cu
@@ -3,68 +3,15 @@
 #include <vector>
 #include <chrono>
 
+#include "parameters.h"
+
 /*
 
 YTZ Notes:
 
 This kernel implements the ANI-1 featurization scheme. It can process about 3.6 million samples/minute
+
 */
-
-const int MAX_ATOM_TYPES = 4;
-
-const int NUM_R_Rs = 16;
-const int RADIAL_FEATURE_SIZE = MAX_ATOM_TYPES * NUM_R_Rs;
-
-const float R_eta = 16;
-const float R_Rc = 4.6;
-
-const float A_Rc = 3.1;
-const float A_eta = 6.0;
-const float A_zeta = 8.0;
-const int NUM_A_THETAS = 8;
-const int NUM_A_RS = 4;
-
-const int ANGULAR_FEATURE_SIZE = NUM_A_RS * NUM_A_THETAS * (MAX_ATOM_TYPES * (MAX_ATOM_TYPES+1) / 2);
-
-const int TOTAL_FEATURE_SIZE = RADIAL_FEATURE_SIZE + ANGULAR_FEATURE_SIZE;
-
-__device__ const float R_Rs[NUM_R_Rs] = {
-    5.0000000e-01,
-    7.5625000e-01,
-    1.0125000e+00,
-    1.2687500e+00,
-    1.5250000e+00,
-    1.7812500e+00,
-    2.0375000e+00,
-    2.2937500e+00,
-    2.5500000e+00,
-    2.8062500e+00,
-    3.0625000e+00,
-    3.3187500e+00,
-    3.5750000e+00,
-    3.8312500e+00,
-    4.0875000e+00,
-    4.3437500e+00
-};
-
-__device__ const float A_thetas[NUM_A_THETAS] = {
-    0.0000000e+00,
-    7.8539816e-01,
-    1.5707963e+00,
-    2.3561945e+00,
-    3.1415927e+00,
-    3.9269908e+00,
-    4.7123890e+00,
-    5.4977871e+00
-};
-
-__device__ const float A_Rs[NUM_A_RS] = {
-    5.0000000e-01,
-    1.1500000e+00,
-    1.8000000e+00,
-    2.4500000e+00,
-};
-
 
 inline __device__ float dist_diff(float dx, float dy, float dz) {
 

--- a/gpu_featurizer/parameters.h
+++ b/gpu_featurizer/parameters.h
@@ -1,0 +1,135 @@
+
+/* from github repo */
+// const int MAX_ATOM_TYPES = 4;
+
+// const int NUM_R_Rs = 16;
+// const int RADIAL_FEATURE_SIZE = MAX_ATOM_TYPES * NUM_R_Rs;
+
+// const float R_eta = 16;
+// const float R_Rc = 4.6;
+
+// const float A_Rc = 3.1;
+// const float A_eta = 6.0;
+// const float A_zeta = 8.0;
+// const int NUM_A_THETAS = 8;
+// const int NUM_A_RS = 4;
+
+// const int ANGULAR_FEATURE_SIZE = NUM_A_RS * NUM_A_THETAS * (MAX_ATOM_TYPES * (MAX_ATOM_TYPES+1) / 2);
+
+// const int TOTAL_FEATURE_SIZE = RADIAL_FEATURE_SIZE + ANGULAR_FEATURE_SIZE;
+
+// __device__ const float R_Rs[NUM_R_Rs] = {
+//     5.0000000e-01,
+//     7.5625000e-01,
+//     1.0125000e+00,
+//     1.2687500e+00,
+//     1.5250000e+00,
+//     1.7812500e+00,
+//     2.0375000e+00,
+//     2.2937500e+00,
+//     2.5500000e+00,
+//     2.8062500e+00,
+//     3.0625000e+00,
+//     3.3187500e+00,
+//     3.5750000e+00,
+//     3.8312500e+00,
+//     4.0875000e+00,
+//     4.3437500e+00
+// };
+
+// __device__ const float A_thetas[NUM_A_THETAS] = {
+//     0.0000000e+00,
+//     7.8539816e-01,
+//     1.5707963e+00,
+//     2.3561945e+00,
+//     3.1415927e+00,
+//     3.9269908e+00,
+//     4.7123890e+00,
+//     5.4977871e+00
+// };
+
+// __device__ const float A_Rs[NUM_A_RS] = {
+//     5.0000000e-01,
+//     1.1500000e+00,
+//     1.8000000e+00,
+//     2.4500000e+00,
+// };
+
+/* from ANI-1 paper */
+
+
+const int MAX_ATOM_TYPES = 4;
+
+const int NUM_R_Rs = 32;
+const int RADIAL_FEATURE_SIZE = MAX_ATOM_TYPES * NUM_R_Rs;
+
+const float R_eta = NUM_R_Rs;
+const float R_Rc = 4.6;
+
+const float A_Rc = 3.1;
+const float A_eta = 6.0;
+const float A_zeta = 8.0;
+const int NUM_A_THETAS = 8;
+const int NUM_A_RS = 8;
+
+const int ANGULAR_FEATURE_SIZE = NUM_A_RS * NUM_A_THETAS * (MAX_ATOM_TYPES * (MAX_ATOM_TYPES+1) / 2);
+
+const int TOTAL_FEATURE_SIZE = RADIAL_FEATURE_SIZE + ANGULAR_FEATURE_SIZE;
+
+// portably transfer over to CPU code?
+__device__ const float R_Rs[NUM_R_Rs] = {
+    0.13939394,
+    0.27878788,
+    0.41818182,
+    0.55757576,
+    0.6969697,
+    0.83636364,
+    0.97575758,
+    1.11515152,
+    1.25454545,
+    1.39393939,
+    1.53333333,
+    1.67272727,
+    1.81212121,
+    1.95151515,
+    2.09090909,
+    2.23030303,
+    2.36969697,
+    2.50909091,
+    2.64848485,
+    2.78787879,
+    2.92727273,
+    3.06666667,
+    3.20606061,
+    3.34545455,
+    3.48484848,
+    3.62424242,
+    3.76363636,
+    3.9030303,
+    4.04242424,
+    4.18181818,
+    4.32121212,
+    4.46060606
+};
+
+__device__ const float A_thetas[NUM_A_THETAS] = {
+    0.0000000e+00,
+    7.8539816e-01,
+    1.5707963e+00,
+    2.3561945e+00,
+    3.1415927e+00,
+    3.9269908e+00,
+    4.7123890e+00,
+    5.4977871e+00
+};
+
+__device__ const float A_Rs[NUM_A_RS] = {
+    0.34444444,
+    0.68888889,
+    1.03333333,
+    1.37777778,
+    1.72222222,
+    2.06666667,
+    2.41111111,
+    2.75555556
+};

--- a/khan/model/nn.py
+++ b/khan/model/nn.py
@@ -38,9 +38,20 @@ class AtomNN():
             name = "_"+atom_type+"_"+str(x)+"x"+str(y)+"_l"+str(idx)
 
             with tf.device('/cpu:0'):
-
-                W = tf.get_variable("W"+name, (x, y), np.float32, tf.random_normal_initializer(mean=0, stddev=1.0/x), trainable=True)
-                b = tf.get_variable("b"+name, (y), np.float32, tf.zeros_initializer, trainable=True)
+                W = tf.get_variable(
+                    "W"+name,
+                    (x, y),
+                    np.float32,
+                    tf.random_normal_initializer(mean=0, stddev=1.0/x),
+                    trainable=True
+                )
+                b = tf.get_variable(
+                    "b"+name,
+                    (y),
+                    np.float32,
+                    tf.zeros_initializer,
+                    trainable=True
+                )
 
             A = tf.matmul(self.As[-1], W) + b
             if idx != len(layer_sizes) - 1:

--- a/khan/training/trainer_multi_gpu.py
+++ b/khan/training/trainer_multi_gpu.py
@@ -61,7 +61,7 @@ def average_gradients(tower_grads):
 
 class TrainerMultiGPU():
 
-    def __init__(self, sess, n_gpus=1):
+    def __init__(self, sess, n_gpus=1, layer_sizes=(128, 128, 64, 1)):
         """
         A queue-enabled multi-gpu trainer. Construction of this class will also
         finalize and initialize all the variables pertaining to the input session.
@@ -135,13 +135,6 @@ class TrainerMultiGPU():
             self.all_models = []
             self.tower_exp_loss = []
 
-
-            # print(dir(ani_mod.ani))
-
-            # self.layer_sizes = (ani_mod.ani.__getattribute__("feat_size"), 256, 128, 64, 1)
-
-            # print(self.layer_sizes)
-
             with tf.variable_scope(tf.get_variable_scope()):
                 for gpu_idx in range(self.num_gpus):
                     with tf.device('/gpu:%d' % gpu_idx):
@@ -175,16 +168,12 @@ class TrainerMultiGPU():
                                 f2 = tf.reshape(f2, (-1, feat_size))
                                 f3 = tf.reshape(f3, (-1, feat_size))
 
-                            layer_sizes = (feat_size, 128, 128, 64, 1)
-
                             tower_model = MoleculeNN(
                                 type_map=["H", "C", "N", "O"],
                                 atom_type_features=[f0, f1, f2, f3],
                                 gather_idxs=gather_idxs,
                                 mol_idxs=m_deq,
-                                layer_sizes=layer_sizes)
-
-
+                                layer_sizes=(feat_size,) + layer_sizes)
 
                             self.all_models.append(tower_model)
 

--- a/khan/training/trainer_multi_gpu.py
+++ b/khan/training/trainer_multi_gpu.py
@@ -175,8 +175,7 @@ class TrainerMultiGPU():
                                 f2 = tf.reshape(f2, (-1, feat_size))
                                 f3 = tf.reshape(f3, (-1, feat_size))
 
-                            layer_sizes = (feat_size, 256, 128, 64, 1)
-
+                            layer_sizes = (feat_size, 128, 128, 64, 1)
 
                             tower_model = MoleculeNN(
                                 type_map=["H", "C", "N", "O"],

--- a/main_2.py
+++ b/main_2.py
@@ -87,7 +87,10 @@ def main():
         # max_local_epoch_count number of epochs have been run and no progress has been made, we decrease the learning
         # rate and restore the best found parameters.
 
-        trainer = TrainerMultiGPU(sess, n_gpus=int(args.gpus))
+        trainer = TrainerMultiGPU(
+            sess,
+            n_gpus=int(args.gpus),
+            layer_sizes=(128, 128, 64, 1))
 
         if os.path.exists(save_dir):
             print("Restoring existing model from", save_dir)


### PR DESCRIPTION
Addresses #15 partially. Due to speed reasons, you will still need to recompile the CUDA code with custom kernels. But this allows the end-user to modify only a single parameters.h file when determining which featurization parameters to use. Feature sizes are now inferred through the op kernel via some black magic.