### PR TITLE
Charge correction normalization

### DIFF
--- a/khan/model/nn.py
+++ b/khan/model/nn.py
@@ -162,6 +162,7 @@ class MoleculeNN():
             atom_type_nrgs.append(ann.atom_energies())
 
         self.atom_outputs = tf.gather(tf.concat(atom_type_nrgs, axis=0), gather_idxs)
+        self.atom_outputs = tf.reshape(self.atom_outputs, (-1, )) # (batch_size,)
         # self.mol_nrgs = tf.reshape(tf.segment_sum(self.atom_nrgs, mol_idxs), (-1,))
 
     # def atom_outputs(self):

--- a/khan/training/trainer_multi_tower.py
+++ b/khan/training/trainer_multi_tower.py
@@ -246,8 +246,7 @@ class TrainerMultiTower():
                                 prefix="near_")
 
                             self.all_models.append(tower_model_near)
-                            tower_near_energy = tf.reshape(tf.segment_sum(tower_model_near.atom_outputs, m_deq), (-1,))
-
+                            tower_near_energy = tf.segment_sum(tower_model_near.atom_outputs, m_deq)
                             if fit_charges:
                                 tower_model_charges = MoleculeNN(
                                     type_map=["H", "C", "N", "O"],
@@ -258,6 +257,15 @@ class TrainerMultiTower():
 
                                 self.all_models.append(tower_model_charges)
                                 tower_charges = tower_model_charges.atom_outputs
+
+                                # (ytz + stevenso): we want to normalize the compute the charge per molecule
+                                # note that this only works for *neutral* molecules. For molecules that have a formal charge
+                                # we want to specify correct differently, or turn off the normalization entirely.
+                                tower_charges_per_mol = tf.segment_sum(tower_charges, m_deq) # per molecule charge
+                                tower_charges_per_mol = tf.divide(tower_charges_per_mol, tf.cast(mol_atom_counts, dtype=tf.float32)) # per molecule avg charge
+                                tower_charge_correction = tf.gather(tower_charges_per_mol, m_deq) # generate the per atom correction
+                                tower_charges = tf.subtract(tower_charges, tower_charge_correction) # zero out the charge
+
                                 tower_far_energy = ani_mod.ani_charge(
                                     x_deq,
                                     y_deq,


### PR DESCRIPTION
@jminuse :eyes:

Note that this implementation is a little brittle in that it only works for neutral molecules. For charged molecules you'd want to offset the tower_charge_correction by the total formal charge.