### PR TITLE
Allow GPU to be used optionally

### DIFF
--- a/gpu_featurizer/Makefile
+++ b/gpu_featurizer/Makefile
@@ -1,3 +1,8 @@
+# Makefile for the custom tensorflow ops required for ANI-1
+# By default, this will attempt to build the GPU kernels with NVCC in addition to the CPU kernels.
+# If you'd like to build only the cpu kernel, please run: make ani_cpu
+# This will generate a cpu only ani_cpu.so file that can be run on machines with or without GPUs.
+
 CUDA_INCLUDE_FLAGS=-I /usr/local/
 NVCC=nvcc
 TF_CFLAGS=-I/home/yutong/venv/lib/python3.5/site-packages/tensorflow/include -I/home/yutong/venv/lib/python3.5/site-packages/tensorflow/include/external/nsync/public -D_GLIBCXX_USE_CXX11_ABI=0
@@ -10,8 +15,11 @@ CC_LINK_FLAGS=$(TF_LFLAGS)
 
 all: ani
 
-ani: functor_op_cpu.o functor_op_gpu.o kernel.o kernel_cpu.o ani_op.o ani_sort.o ani_charges.o ani_charges_gpu.o
-	$(CC) -shared -o ani.so functor_op_cpu.o functor_op_gpu.o kernel.o kernel_cpu.o ani_charges.o ani_charges_gpu.o ani_op.o ani_sort.o $(CC_FLAGS) $(CC_LINK_FLAGS)
+ani: functor_op_cpu.o functor_op_gpu.o kernel.o kernel_cpu.o ani_op_gpu.o ani_sort.o ani_charges.o ani_charges_gpu.o
+	$(CC) -shared -o ani.so functor_op_cpu.o functor_op_gpu.o kernel.o kernel_cpu.o ani_charges.o ani_charges_gpu.o ani_op_gpu.o ani_sort.o $(CC_FLAGS) $(CC_LINK_FLAGS)
+
+ani_cpu: functor_op_cpu.o kernel_cpu.o ani_op_cpu.o ani_sort.o ani_charges.o
+	$(CC) -shared -o ani_cpu.so functor_op_cpu.o kernel_cpu.o ani_charges.o ani_op_cpu.o ani_sort.o $(CC_FLAGS) $(CC_LINK_FLAGS)
 
 ani_charges_gpu.o: ani_charges_gpu.cu parameters.h
 	$(NVCC) ani_charges_gpu.cu -c $(NVCC_FLAGS)
@@ -28,8 +36,11 @@ kernel_cpu.o: kernel_cpu.cpp parameters.h
 functor_op_cpu.o: functor_op_cpu.cpp functor_op.h parameters.h kernel_cpu.h
 	$(CC) functor_op_cpu.cpp -c $(CC_FLAGS)
 
-ani_op.o: ani_op.cpp functor_op.h parameters.h
-	$(CC) ani_op.cpp -c $(CC_FLAGS)
+ani_op_gpu.o: ani_op.cpp functor_op.h parameters.h
+	$(CC) -o ani_op_gpu.o ani_op.cpp -D ANI_GPU -c $(CC_FLAGS)
+
+ani_op_cpu.o: ani_op.cpp functor_op.h parameters.h
+	$(CC) -o ani_op_cpu.o ani_op.cpp -c $(CC_FLAGS)
 
 ani_sort.o: ani_sort.cpp
 	$(CC) ani_sort.cpp -c $(CC_FLAGS)

--- a/gpu_featurizer/ani_op.cpp
+++ b/gpu_featurizer/ani_op.cpp
@@ -218,9 +218,8 @@ REGISTER_OP("FeaturizeGrad")
     return Status::OK();
   });
 
-
-
-// REGISTER_KERNEL_BUILDER(Name("Ani").Device(DEVICE_CPU).HostMemory("acs"), AniReference);
-REGISTER_KERNEL_BUILDER(Name("Featurize").HostMemory("acs").Device(DEVICE_GPU), AniCombined<GPUDevice>);
+#ifdef ANI_GPU
+  REGISTER_KERNEL_BUILDER(Name("Featurize").HostMemory("acs").Device(DEVICE_GPU), AniCombined<GPUDevice>);
+#endif
 REGISTER_KERNEL_BUILDER(Name("Featurize").HostMemory("acs").Device(DEVICE_CPU), AniCombined<CPUDevice>);
 REGISTER_KERNEL_BUILDER(Name("FeaturizeGrad").HostMemory("acs").Device(DEVICE_CPU), AniCombinedGrad<CPUDevice>);


### PR DESCRIPTION
This PR cleans up the Makefile a little bit so we can generate a custom tf op library without GPU kernels. Useful for debugging locally and deploying models for inference use.

Use: make ani_cpu
Generates an ani_cpu.so file that you can then use.

@leifjacobson @jminuse should make your lives easier.
